### PR TITLE
Upgrade bcrypt version to 3.0.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "sns",
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^1.0.3",
+    "bcrypt": "^3.0.0",
     "csurf": "^1.9.0",
     "ejs": "^2.5.7",
     "express": "^4.16.2",


### PR DESCRIPTION
Bcrypt 1.0.3 fails to install with Node 10. 

This PR contains an edit to package.json upgrading Bcrypt 1.0.3 to 3.0.0.